### PR TITLE
Update utils.py

### DIFF
--- a/vidr/utils.py
+++ b/vidr/utils.py
@@ -6,7 +6,7 @@ from torch.nn import functional as F
 
 #Import single cell modules
 import scanpy as sc
-from scvi.data import setup_anndata
+from scvi.data import setup_anndata # setup_anndata is no longer available in scvi.data
 from scvi.dataloaders import AnnDataLoader
 
 #Other important modules


### PR DESCRIPTION
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
Cell In[34], line 1
----> 1 import utils


      7 #Import single cell modules
      8 import scanpy as sc
----> 9 from scvi.data import setup_anndata
     10 from scvi.dataloaders import AnnDataLoader
     12 #Other important modules

ImportError: cannot import name 'setup_anndata' from 'scvi.data'

I used a try-except block to get around this issue for now:

try:
    import utils
except ImportError:
    print("setup_anndata is not available")
    setup_anndata = None

Output: setup_anndata is not available